### PR TITLE
[OG-122] Support Visca TCP connection interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(LIBVISCA_FILES
     include/${PROJECT_NAME}/libvisca.h
     src/lib/visca/libvisca.c
     src/lib/visca/libvisca_posix.c
+    src/lib/visca/libvisca_tcp.c
    )
 
 add_library(${PROJECT_NAME} ${LIBVISCA_FILES})

--- a/include/libvisca2/libvisca.h
+++ b/include/libvisca2/libvisca.h
@@ -560,6 +560,17 @@ VISCA_unread_bytes(VISCAInterface_t *iface, unsigned char *buffer, uint32_t *buf
 VISCA_API uint32_t
 VISCA_close_serial(VISCAInterface_t *iface);
 
+/* TCP/IP CONNECTION FUNCTIONS */
+
+VISCA_API uint32_t
+VISCA_open_tcp(VISCAInterface_t *iface, const char *hostname, uint32_t port);
+
+VISCA_API uint32_t
+VISCA_close_tcp(VISCAInterface_t *iface);
+
+VISCA_API uint32_t
+VISCA_tcp_bytes_available(VISCAInterface_t *iface, uint32_t *available);
+
 /* COMMANDS */
 
 VISCA_API uint32_t

--- a/src/lib/visca/libvisca_posix.c
+++ b/src/lib/visca/libvisca_posix.c
@@ -27,16 +27,10 @@
 #include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/time.h>
+#include <stdio.h>
 
 /* Timeout for waiting for a response packet (in seconds) */
 #define VISCA_READ_TIMEOUT_SEC  5
-
-/* Debug flag - set to 1 for verbose output */
-#define DEBUG 0
-
-#if DEBUG
-#include <stdio.h>
-#endif
 
 /* implemented in libvisca.c
  */
@@ -79,10 +73,8 @@ _VISCA_send_packet(VISCAInterface_t *iface, VISCACamera_t *camera, VISCAPacket_t
     // check data:
     if ((iface->address>7)||(camera->address>7)||(iface->broadcast>1))
     {
-#if DEBUG
 	fprintf(stderr,"(%s): Invalid header parameters\n",__FILE__);
 	fprintf(stderr," %d %d %d   \n",iface->address,camera->address,iface->broadcast);
-#endif
 	return VISCA_FAILURE;
     }
 
@@ -127,14 +119,10 @@ _VISCA_wait_for_data(int fd, int timeout_sec)
     ret = select(fd + 1, &read_fds, NULL, NULL, &tv);
 
     if (ret < 0) {
-#if DEBUG
         fprintf(stderr, "(%s): select() error: %s\n", __FILE__, strerror(errno));
-#endif
         return -1;  /* Error */
     } else if (ret == 0) {
-#if DEBUG
         fprintf(stderr, "(%s): select() timeout after %d seconds\n", __FILE__, timeout_sec);
-#endif
         return 0;   /* Timeout */
     }
 
@@ -151,18 +139,14 @@ _VISCA_get_packet(VISCAInterface_t *iface)
     /* Wait for initial data with timeout */
     wait_result = _VISCA_wait_for_data(iface->port_fd, VISCA_READ_TIMEOUT_SEC);
     if (wait_result <= 0) {
-#if DEBUG
         fprintf(stderr, "(%s): Timeout or error waiting for VISCA response\n", __FILE__);
-#endif
         return VISCA_FAILURE;
     }
 
     /* Read first byte */
     bytes_read = read(iface->port_fd, iface->ibuf, 1);
     if (bytes_read != 1) {
-#if DEBUG
         fprintf(stderr, "(%s): Failed to read first byte\n", __FILE__);
-#endif
         return VISCA_FAILURE;
     }
 
@@ -172,26 +156,20 @@ _VISCA_get_packet(VISCAInterface_t *iface)
 
         /* Prevent buffer overflow */
         if (pos >= VISCA_INPUT_BUFFER_SIZE - 1) {
-#if DEBUG
             fprintf(stderr, "(%s): Input buffer overflow\n", __FILE__);
-#endif
             return VISCA_FAILURE;
         }
 
         /* Wait for next byte with timeout */
         wait_result = _VISCA_wait_for_data(iface->port_fd, VISCA_READ_TIMEOUT_SEC);
         if (wait_result <= 0) {
-#if DEBUG
             fprintf(stderr, "(%s): Timeout or error waiting for next byte (pos=%d)\n", __FILE__, pos);
-#endif
             return VISCA_FAILURE;
         }
 
         bytes_read = read(iface->port_fd, &iface->ibuf[pos], 1);
         if (bytes_read != 1) {
-#if DEBUG
             fprintf(stderr, "(%s): Failed to read byte at pos %d\n", __FILE__, pos);
-#endif
             return VISCA_FAILURE;
         }
     }
@@ -214,9 +192,7 @@ VISCA_open_serial(VISCAInterface_t *iface, const char *device_name)
 
   if (fd == -1)
     {
-#if DEBUG
       fprintf(stderr,"(%s): cannot open serial device %s\n",__FILE__,device_name);
-#endif
       iface->port_fd=-1;
       return VISCA_FAILURE;
     }	

--- a/src/lib/visca/libvisca_posix.c
+++ b/src/lib/visca/libvisca_posix.c
@@ -25,6 +25,18 @@
 #include <errno.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
+#include <sys/time.h>
+
+/* Timeout for waiting for a response packet (in seconds) */
+#define VISCA_READ_TIMEOUT_SEC  5
+
+/* Debug flag - set to 1 for verbose output */
+#define DEBUG 0
+
+#if DEBUG
+#include <stdio.h>
+#endif
 
 /* implemented in libvisca.c
  */
@@ -92,28 +104,99 @@ _VISCA_send_packet(VISCAInterface_t *iface, VISCACamera_t *camera, VISCAPacket_t
 }
 
 
+/**
+ * Wait for data to be available on the file descriptor with timeout.
+ *
+ * @param fd        File descriptor to wait on
+ * @param timeout_sec  Timeout in seconds
+ * @return          1 if data available, 0 on timeout, -1 on error
+ */
+static int
+_VISCA_wait_for_data(int fd, int timeout_sec)
+{
+    fd_set read_fds;
+    struct timeval tv;
+    int ret;
+
+    FD_ZERO(&read_fds);
+    FD_SET(fd, &read_fds);
+
+    tv.tv_sec = timeout_sec;
+    tv.tv_usec = 0;
+
+    ret = select(fd + 1, &read_fds, NULL, NULL, &tv);
+
+    if (ret < 0) {
+#if DEBUG
+        fprintf(stderr, "(%s): select() error: %s\n", __FILE__, strerror(errno));
+#endif
+        return -1;  /* Error */
+    } else if (ret == 0) {
+#if DEBUG
+        fprintf(stderr, "(%s): select() timeout after %d seconds\n", __FILE__, timeout_sec);
+#endif
+        return 0;   /* Timeout */
+    }
+
+    return 1;  /* Data available */
+}
+
 uint32_t
 _VISCA_get_packet(VISCAInterface_t *iface)
 {
-    int pos=0;
+    int pos = 0;
     int bytes_read;
+    int wait_result;
 
-    // wait for message
-    ioctl(iface->port_fd, FIONREAD, &(iface->bytes));
-    while (iface->bytes==0) {
-	usleep(0);
-	ioctl(iface->port_fd, FIONREAD, &(iface->bytes));
+    /* Wait for initial data with timeout */
+    wait_result = _VISCA_wait_for_data(iface->port_fd, VISCA_READ_TIMEOUT_SEC);
+    if (wait_result <= 0) {
+#if DEBUG
+        fprintf(stderr, "(%s): Timeout or error waiting for VISCA response\n", __FILE__);
+#endif
+        return VISCA_FAILURE;
     }
 
-    // get octets one by one
-    bytes_read=read(iface->port_fd, iface->ibuf, 1);
-    while (iface->ibuf[pos]!=VISCA_TERMINATOR) {
-	pos++;
-	bytes_read=read(iface->port_fd, &iface->ibuf[pos], 1);
-	usleep(0);
+    /* Read first byte */
+    bytes_read = read(iface->port_fd, iface->ibuf, 1);
+    if (bytes_read != 1) {
+#if DEBUG
+        fprintf(stderr, "(%s): Failed to read first byte\n", __FILE__);
+#endif
+        return VISCA_FAILURE;
     }
-    iface->bytes=pos+1;
 
+    /* Read remaining bytes until terminator */
+    while (iface->ibuf[pos] != VISCA_TERMINATOR) {
+        pos++;
+
+        /* Prevent buffer overflow */
+        if (pos >= VISCA_INPUT_BUFFER_SIZE - 1) {
+#if DEBUG
+            fprintf(stderr, "(%s): Input buffer overflow\n", __FILE__);
+#endif
+            return VISCA_FAILURE;
+        }
+
+        /* Wait for next byte with timeout */
+        wait_result = _VISCA_wait_for_data(iface->port_fd, VISCA_READ_TIMEOUT_SEC);
+        if (wait_result <= 0) {
+#if DEBUG
+            fprintf(stderr, "(%s): Timeout or error waiting for next byte (pos=%d)\n", __FILE__, pos);
+#endif
+            return VISCA_FAILURE;
+        }
+
+        bytes_read = read(iface->port_fd, &iface->ibuf[pos], 1);
+        if (bytes_read != 1) {
+#if DEBUG
+            fprintf(stderr, "(%s): Failed to read byte at pos %d\n", __FILE__, pos);
+#endif
+            return VISCA_FAILURE;
+        }
+    }
+
+    iface->bytes = pos + 1;
     return VISCA_SUCCESS;
 }
 

--- a/src/lib/visca/libvisca_tcp.c
+++ b/src/lib/visca/libvisca_tcp.c
@@ -1,0 +1,198 @@
+/*
+ * VISCA(tm) Camera Control Library - TCP/IP Extension
+ * Copyright (C) 2025 Energy Robotics
+ *
+ * Based on libvisca by Damien Douxchamps
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <libvisca2/libvisca.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/ioctl.h>
+
+/* Debug flag - set to 1 for verbose output */
+#define DEBUG 0
+
+#if DEBUG
+#include <stdio.h>
+#endif
+
+/**
+ * Opens a TCP connection to a VISCA camera/interface.
+ * 
+ * This function creates a TCP socket and connects to the specified
+ * hostname and port. The resulting socket file descriptor is stored
+ * in iface->port_fd, allowing reuse of the existing VISCA read/write
+ * functions that operate on file descriptors.
+ *
+ * @param iface     Pointer to the VISCA interface structure
+ * @param hostname  Hostname or IP address of the VISCA device
+ * @param port      TCP port number (typically 1000 for FV4K or 52381 for VISCA-over-IP)
+ * @return          VISCA_SUCCESS on success, VISCA_FAILURE on error
+ */
+uint32_t
+VISCA_open_tcp(VISCAInterface_t *iface, const char *hostname, uint32_t port)
+{
+    int sockfd;
+    struct sockaddr_in server_addr;
+    struct hostent *server;
+    int flags;
+    int optval;
+
+    /* Create TCP socket */
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd < 0)
+    {
+#if DEBUG
+        fprintf(stderr, "(%s): cannot create socket\n", __FILE__);
+#endif
+        iface->port_fd = -1;
+        return VISCA_FAILURE;
+    }
+
+    /* Resolve hostname */
+    server = gethostbyname(hostname);
+    if (server == NULL)
+    {
+#if DEBUG
+        fprintf(stderr, "(%s): cannot resolve hostname %s\n", __FILE__, hostname);
+#endif
+        close(sockfd);
+        iface->port_fd = -1;
+        return VISCA_FAILURE;
+    }
+
+    /* Set up server address structure */
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    memcpy(&server_addr.sin_addr.s_addr, server->h_addr, server->h_length);
+    server_addr.sin_port = htons(port);
+
+    /* Connect to server */
+    if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0)
+    {
+#if DEBUG
+        fprintf(stderr, "(%s): cannot connect to %s:%d - %s\n", 
+                __FILE__, hostname, port, strerror(errno));
+#endif
+        close(sockfd);
+        iface->port_fd = -1;
+        return VISCA_FAILURE;
+    }
+
+    /* Set TCP_NODELAY to disable Nagle's algorithm for low latency */
+    optval = 1;
+    if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval)) < 0)
+    {
+#if DEBUG
+        fprintf(stderr, "(%s): warning - cannot set TCP_NODELAY\n", __FILE__);
+#endif
+        /* Non-fatal, continue anyway */
+    }
+
+    /* Set socket to non-blocking mode initially, then switch to blocking for I/O */
+    /* Actually, keep it blocking for simpler read/write operations */
+    flags = fcntl(sockfd, F_GETFL, 0);
+    if (flags >= 0)
+    {
+        /* Ensure blocking mode */
+        fcntl(sockfd, F_SETFL, flags & ~O_NONBLOCK);
+    }
+
+    /* Set socket receive timeout (5 seconds) */
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    /* Store socket fd and initialize interface */
+    iface->port_fd = sockfd;
+    iface->address = 0;
+    iface->broadcast = 0;
+    iface->bytes = 0;
+
+#if DEBUG
+    fprintf(stderr, "(%s): connected to %s:%d (fd=%d)\n", 
+            __FILE__, hostname, port, sockfd);
+#endif
+
+    return VISCA_SUCCESS;
+}
+
+/**
+ * Closes a TCP connection to a VISCA camera/interface.
+ *
+ * @param iface     Pointer to the VISCA interface structure
+ * @return          VISCA_SUCCESS on success, VISCA_FAILURE on error
+ */
+uint32_t
+VISCA_close_tcp(VISCAInterface_t *iface)
+{
+    if (iface->port_fd != -1)
+    {
+        /* Graceful shutdown */
+        shutdown(iface->port_fd, SHUT_RDWR);
+        close(iface->port_fd);
+        iface->port_fd = -1;
+
+#if DEBUG
+        fprintf(stderr, "(%s): TCP connection closed\n", __FILE__);
+#endif
+        return VISCA_SUCCESS;
+    }
+    else
+    {
+        return VISCA_FAILURE;
+    }
+}
+
+/**
+ * Checks if there are bytes available to read on the TCP socket.
+ * This is useful for non-blocking checks before attempting to read.
+ *
+ * @param iface     Pointer to the VISCA interface structure
+ * @param available Pointer to store the number of available bytes
+ * @return          VISCA_SUCCESS on success, VISCA_FAILURE on error
+ */
+uint32_t
+VISCA_tcp_bytes_available(VISCAInterface_t *iface, uint32_t *available)
+{
+    int bytes = 0;
+    
+    if (iface->port_fd == -1)
+    {
+        *available = 0;
+        return VISCA_FAILURE;
+    }
+    
+    if (ioctl(iface->port_fd, FIONREAD, &bytes) < 0)
+    {
+        *available = 0;
+        return VISCA_FAILURE;
+    }
+    
+    *available = (uint32_t)bytes;
+    return VISCA_SUCCESS;
+}

--- a/src/lib/visca/libvisca_tcp.c
+++ b/src/lib/visca/libvisca_tcp.c
@@ -31,13 +31,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <sys/ioctl.h>
-
-/* Debug flag - set to 1 for verbose output */
-#define DEBUG 0
-
-#if DEBUG
 #include <stdio.h>
-#endif
 
 /**
  * Opens a TCP connection to a VISCA camera/interface.
@@ -65,9 +59,7 @@ VISCA_open_tcp(VISCAInterface_t *iface, const char *hostname, uint32_t port)
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
     if (sockfd < 0)
     {
-#if DEBUG
         fprintf(stderr, "(%s): cannot create socket\n", __FILE__);
-#endif
         iface->port_fd = -1;
         return VISCA_FAILURE;
     }
@@ -76,9 +68,7 @@ VISCA_open_tcp(VISCAInterface_t *iface, const char *hostname, uint32_t port)
     server = gethostbyname(hostname);
     if (server == NULL)
     {
-#if DEBUG
         fprintf(stderr, "(%s): cannot resolve hostname %s\n", __FILE__, hostname);
-#endif
         close(sockfd);
         iface->port_fd = -1;
         return VISCA_FAILURE;
@@ -93,10 +83,8 @@ VISCA_open_tcp(VISCAInterface_t *iface, const char *hostname, uint32_t port)
     /* Connect to server */
     if (connect(sockfd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0)
     {
-#if DEBUG
         fprintf(stderr, "(%s): cannot connect to %s:%d - %s\n", 
                 __FILE__, hostname, port, strerror(errno));
-#endif
         close(sockfd);
         iface->port_fd = -1;
         return VISCA_FAILURE;
@@ -106,9 +94,7 @@ VISCA_open_tcp(VISCAInterface_t *iface, const char *hostname, uint32_t port)
     optval = 1;
     if (setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval)) < 0)
     {
-#if DEBUG
         fprintf(stderr, "(%s): warning - cannot set TCP_NODELAY\n", __FILE__);
-#endif
         /* Non-fatal, continue anyway */
     }
 
@@ -133,10 +119,8 @@ VISCA_open_tcp(VISCAInterface_t *iface, const char *hostname, uint32_t port)
     iface->broadcast = 0;
     iface->bytes = 0;
 
-#if DEBUG
     fprintf(stderr, "(%s): connected to %s:%d (fd=%d)\n", 
             __FILE__, hostname, port, sockfd);
-#endif
 
     return VISCA_SUCCESS;
 }
@@ -157,9 +141,7 @@ VISCA_close_tcp(VISCAInterface_t *iface)
         close(iface->port_fd);
         iface->port_fd = -1;
 
-#if DEBUG
         fprintf(stderr, "(%s): TCP connection closed\n", __FILE__);
-#endif
         return VISCA_SUCCESS;
     }
     else


### PR DESCRIPTION
1. Adds the ability to communicate with VISCA cameras over TCP/IP instead of only serial.
2. Calls _VISCA_wait_for_data() with a 5-second timeout before the initial read, returning VISCA_FAILURE on timeout instead of hanging.
3. Validates that each read() call returns exactly 1 byte, returning VISCA_FAILURE on read errors.
4. Adds a buffer overflow guard (pos >= VISCA_INPUT_BUFFER_SIZE - 1) that was entirely absent before.
5. Uses _VISCA_wait_for_data() with timeout before each subsequent byte read in the terminator loop.