### PR TITLE
Increase visca read timeout to 20s

### DIFF
--- a/src/lib/visca/libvisca_posix.c
+++ b/src/lib/visca/libvisca_posix.c
@@ -30,7 +30,7 @@
 #include <stdio.h>
 
 /* Timeout for waiting for a response packet (in seconds) */
-#define VISCA_READ_TIMEOUT_SEC  5
+#define VISCA_READ_TIMEOUT_SEC 20
 
 /* implemented in libvisca.c
  */


### PR DESCRIPTION
This avoids timeouts for long running commands, e.g. full zoom movement from min to max zoom